### PR TITLE
permit direct call through to DP forwarding handler

### DIFF
--- a/src/gtp_u_edp_handler.erl
+++ b/src/gtp_u_edp_handler.erl
@@ -8,7 +8,7 @@
 -module(gtp_u_edp_handler).
 
 %% API
--export([start_link/7, add_tunnel/6, update_tunnel/6, del_tunnel/1, handle_msg/6]).
+-export([start_link/7, add_tunnel/6, handle_msg/6]).
 
 -include_lib("gtplib/include/gtp_packet.hrl").
 
@@ -25,16 +25,6 @@ start_link(Port, PeerIP, LocalTEI, RemoteTEI, Owner, HandlerMod, HandlerArgs) ->
 add_tunnel(Port, PeerIP, LocalTEI, RemoteTEI, Owner, {Handler, HandlerArgs}) ->
     HandlerMod = map_handler(Handler),
     gtp_u_edp_handler_sup:add_tunnel(Port, PeerIP, LocalTEI, RemoteTEI, Owner, HandlerMod, HandlerArgs).
-
-update_tunnel(Pid, PortName, PeerIP, LocalTEI, RemoteTEI, {forward, Args})
-  when is_list(Args)->
-    gen_server:call(Pid, [update_tunnel, PortName, PeerIP, LocalTEI, RemoteTEI | Args]);
-update_tunnel(Pid, PortName, PeerIP, LocalTEI, RemoteTEI, Args)
-  when is_list(Args)->
-    gen_server:call(Pid, [update_tunnel, PortName, PeerIP, LocalTEI, RemoteTEI | Args]).
-
-del_tunnel(Pid) ->
-    gen_server:cast(Pid, del_tunnel).
 
 handle_msg(Name, Socket, Req, IP, Port, #gtp{type = g_pdu, tei = TEI, seq_no = _SeqNo} = Msg)
   when is_integer(TEI), TEI /= 0 ->

--- a/src/gtp_u_edp_port.erl
+++ b/src/gtp_u_edp_port.erl
@@ -114,27 +114,27 @@ handle_call({create_pdp_context, PeerIP, LocalTEI, RemoteTEI, Args} = _Request,
 
     {reply, Reply, State};
 
-handle_call({update_pdp_context, PeerIP, LocalTEI, RemoteTEI, Args} = _Request,
+handle_call({update_pdp_context, _, LocalTEI, _, _} = Request,
 	    _From, #state{name = Name} = State) ->
 
-    lager:info("EDP Port Update PDP Context Call ~p: ~p", [_From, _Request]),
+    lager:info("EDP Port Update PDP Context Call ~p: ~p", [_From, Request]),
     Reply =
 	case gtp_u_edp:lookup({Name, LocalTEI}) of
 	    Pid when is_pid(Pid) ->
-		gtp_u_edp_handler:update_tunnel(Pid, Name, PeerIP, LocalTEI, RemoteTEI, Args);
+		gen_server:call(Pid, Request);
 	    _ ->
 		{error, not_found}
 	end,
     {reply, Reply, State};
 
-handle_call({delete_pdp_context, _PeerIP, LocalTEI, _RemoteTEI, _Args} = _Request,
+handle_call({delete_pdp_context, _, LocalTEI, _, _} = Request,
 	    _From, #state{name = Name} = State) ->
 
-    lager:info("EDP Port Delete PDP Context Call ~p: ~p", [_From, _Request]),
+    lager:info("EDP Port Delete PDP Context Call ~p: ~p", [_From, Request]),
     Reply =
 	case gtp_u_edp:lookup({Name, LocalTEI}) of
 	    Pid when is_pid(Pid) ->
-		gtp_u_edp_handler:del_tunnel(Pid);
+		gen_server:call(Pid, Request);
 	    _ ->
 		{error, not_found}
 	end,


### PR DESCRIPTION
This allows us to take advantage of the new DP pid handling
feature in ergW. Update and Delete PDP Requests can bypass
the registry and directly call the DP handler.