### PR TITLE
Maintenance: upgrade dependencies

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,16 +1,24 @@
 {erl_opts, [debug_info, {parse_transform, lager_transform}]}.
 
 {deps, [
-	{meck, ".*", {git, "https://github.com/eproxus/meck.git", {tag,"0.8.7"}}},
-	{lager, "3.4.2"},
-	{erlando, ".*", {git, "https://github.com/travelping/erlando.git", "master"}},
-	{gtplib, ".*", {git, "https://github.com/travelping/gtplib.git", {branch, "master"}}},
-	{exometer_core, ".*", {git, "https://github.com/Feuerlabs/exometer_core.git", "master"}},
-	{gen_socket, ".*", {git, "https://github.com/travelping/gen_socket.git", {branch, "master"}}}
+	{lager, "3.6.3"},
+	{exometer_core, "1.5.2"},
+	{erlando, {git, "https://github.com/travelping/erlando.git", {tag, "1.0.0"}}},
+	{gen_socket, {git, "https://github.com/travelping/gen_socket.git", {tag, "0.6.3"}}},
+	{gtplib, {git, "https://github.com/travelping/gtplib.git", {branch, "master"}}}
 ]}.
 
 {minimum_otp_vsn, "19"}.
 {plugins, []}.
+
+{profiles, [
+	    {test, [
+		    {erl_opts, [nowarn_export_all]},
+		    {deps, [
+			    {meck, "0.8.8"}
+			   ]}
+		   ]}
+	   ]}.
 
 %% xref checks to run
 {xref_checks, [undefined_function_calls, undefined_functions,


### PR DESCRIPTION
The upgraded dependencies include fixes and improvements in their
respective upstream projects.

Also, the `meck` dependency is used only if a "test" profile is used.
This way it does not clutter the dependency tree in production releases.