### PR TITLE
Improve memory consumption

### DIFF
--- a/src/gtp_u_edp_metrics.erl
+++ b/src/gtp_u_edp_metrics.erl
@@ -17,7 +17,17 @@
 -include_lib("gtplib/include/gtp_packet.hrl").
 -include("include/gtp_u_edp.hrl").
 
--define(EXO_PERF_OPTS, [{time_span, 300 * 1000}]).		%% 5 min histogram
+-define(EXO_PERF_OPTS, [
+		        {time_span, 300 * 1000},  %% 5 min histogram
+
+		        %% exometer spawns a process per historgram
+		        %% the default exometer-`min_heap_size` for such a
+		        %% process is about 40k words (320+ kbyte). this
+		        %% results in measurable memory overhead per
+		        %% histogram. we set `min_heap_size` to 233, as
+		        %% described in the Erlang Efficiency Guide, see
+		        %% http://erlang.org/doc/efficiency_guide/advanced.html#id71365
+		        {min_heap_size, 233}]).
 -define(GTP_U_MSGS, [echo_request, version_not_supported,
 		      end_marker, g_pdu]).
 -define(GTP_U_ERRS, [context_not_found,


### PR DESCRIPTION
For every established GTP-U connection, several metric probes are
created upon connection (see src/gtp_u_edp_port.erl). Among the created
probes are 2 of type "histogram". An histogram is represented as a
process in the GTP-U-Node which will be initialized with a
`min_heap_size` of 40k WORDS (8byte on 64bit machines).

See [1] and [2] for a discussion about the issue.

Neither of the preconditions for increasing the `min_heap_size` are met:

* the histograms are kept over a long period of time (and are not short
  lived)
* the amount of processes keep growing with the amount of established
  connections

This commit sets the `min_heap_size` option of the spawned processes
responsible for the histogram to the default Erlang value and thus,
decreases the memory consumption of the histograms and allow the GC to
work.

[1]: https://github.com/Feuerlabs/exometer_core/issues/100
[2]: http://erlang.org/doc/efficiency_guide/processes.html